### PR TITLE
feat: Constructive Dissent CLI Integration

### DIFF
--- a/plan/implementation_plan_constructive_dissent_04092026.md
+++ b/plan/implementation_plan_constructive_dissent_04092026.md
@@ -1,0 +1,28 @@
+# ADR-CD: Constructive Dissent CLI Integration
+
+## Overview
+Implement the `--dissent` flag in `query.py` to expose the engine's "Constructive Dissent" feature. This feature mathematically detects minority opinions during the Stage 2 Peer Review process and surfaces them to the user.
+
+## User Review Required
+> [!NOTE]
+> This feature is distinct from the Devil's Advocate. 
+> - **Devil's Advocate**: A proactive critique from a reserved model.
+> - **Constructive Dissent**: A reactive extraction of disagreements between models during the voting phase.
+
+## Proposed Changes
+
+### CLI Layer
+
+#### [MODIFY] [query.py](file:///c:/git_projects/llm-council/query.py)
+- Add `--dissent` argument to `argparse`.
+- Update `run_full_council` call to include `include_dissent=args.dissent`.
+- Add a new display section for `metadata.get("dissent")` in the terminal output.
+
+### Verification Plan
+
+#### Automated Tests
+- Create `tests/test_dissent_integration.py` to verify that `run_full_council` correctly populates the `metadata["dissent"]` field when `include_dissent=True`.
+- Run the full test suite `uv run pytest tests/ -v`.
+
+#### Manual Verification
+- Run a query with `--dissent` and models that are likely to disagree (e.g., a mix of GPT-4 and Haiku on a complex topic) to ensure the minority perspective is surfaced.

--- a/query.py
+++ b/query.py
@@ -34,6 +34,11 @@ async def main():
         dest="adversary",
         help="Disable Reactive Devil's Advocate mode",
     )
+    parser.add_argument(
+        "--dissent",
+        action="store_true",
+        help="Enable Constructive Dissent (detects minority opinions during voting)",
+    )
 
     args = parser.parse_args()
 
@@ -54,7 +59,10 @@ async def main():
         print(f"[*] Stage 1: Collecting initial opinions (Confidence: {args.confidence})...")
 
         stage1, stage2, stage3, metadata = await run_full_council(
-            args.query, bypass_cache=args.no_cache, adversarial_mode=args.adversary
+            args.query,
+            bypass_cache=args.no_cache,
+            adversarial_mode=args.adversary,
+            include_dissent=args.dissent,
         )
 
         print("[*] Stage 2: Peer reviewing and ranking...")
@@ -86,6 +94,15 @@ async def main():
             print("-" * 50)
             print(dissent_report)
             print("!" * 50)
+
+        # ADR-CD: Display Constructive Dissent if available
+        dissent_text = metadata.get("dissent")
+        if dissent_text:
+            print("\n" + "." * 50)
+            print("### CONSTRUCTIVE DISSENT (Minority Opinion)")
+            print("-" * 50)
+            print(dissent_text)
+            print("." * 50)
 
         if args.details:
             print("\n" + "=" * 50)

--- a/src/llm_council/council.py
+++ b/src/llm_council/council.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, List, Dict, Any, Tuple, Optional, Callable, Aw
 from llm_council.gateway_adapter import (
     query_models_parallel,
     query_model,
+    query_model_with_status,
     query_models_with_progress,
     STATUS_OK,
     STATUS_TIMEOUT,
@@ -2389,8 +2390,6 @@ async def run_full_council(
         )
 
         da_prompt = get_adversary_report_prompt(user_query, responses_text)
-        from llm_council.gateway_adapter import query_model_with_status
-
         da_response = await query_model_with_status(
             adversary_model,
             [{"role": "user", "content": da_prompt}],

--- a/tests/test_adversarial_logic.py
+++ b/tests/test_adversarial_logic.py
@@ -34,7 +34,7 @@ async def test_adversarial_mode_logic_split():
     with patch("llm_council.council._get_adversarial_mode", return_value=True), \
          patch("llm_council.council._get_adversarial_model", return_value="model4"), \
          patch("llm_council.council.stage1_collect_responses_with_status", new_callable=AsyncMock) as mock_stage1, \
-         patch("llm_council.council.query_model", new_callable=AsyncMock) as mock_query, \
+         patch("llm_council.council.query_model_with_status", new_callable=AsyncMock) as mock_query, \
          patch("llm_council.council.stage1_5_normalize_styles", new_callable=AsyncMock) as mock_norm, \
          patch("llm_council.council.stage2_collect_rankings", new_callable=AsyncMock) as mock_stage2, \
          patch("llm_council.council.stage3_synthesize_final", new_callable=AsyncMock) as mock_stage3:

--- a/tests/test_dissent_integration.py
+++ b/tests/test_dissent_integration.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from llm_council.council import run_full_council
+
+
+@pytest.mark.asyncio
+async def test_dissent_metadata_integration():
+    """Verify that include_dissent correctly populates metadata['dissent']."""
+
+    user_query = "Test query"
+    mock_stage1 = [{"model": "m1", "response": "resp1"}]
+    mock_stage2 = [{"model": "m2", "response": "resp2"}]
+    mock_stage3 = {"response": "synthesis"}
+    mock_metadata = {"dissent": "This is a minority opinion.", "aggregate_rankings": []}
+
+    # We patch run_full_council because we want to test that query.py
+    # would receive and display this metadata.
+    # But since we're testing the integration in the engine first:
+
+    mock_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "total_cost": 0.0}
+
+    with (
+        patch(
+            "llm_council.council.stage1_collect_responses_with_status", new_callable=AsyncMock
+        ) as m1,
+        patch("llm_council.council.stage2_collect_rankings", new_callable=AsyncMock) as m2,
+        patch("llm_council.council.stage3_synthesize_final", new_callable=AsyncMock) as m3,
+        patch(
+            "llm_council.council.extract_dissent_from_stage2",
+            return_value="This is a minority opinion.",
+        ),
+    ):
+        m1.return_value = (mock_stage1, mock_usage, {})
+        m2.return_value = (mock_stage2, {}, mock_usage)
+        m3.return_value = (mock_stage3, mock_usage, None)
+
+        _, _, _, metadata = await run_full_council(user_query, include_dissent=True)
+
+        assert metadata.get("dissent") == "This is a minority opinion."


### PR DESCRIPTION
﻿## Implementation Plan
# ADR-CD: Constructive Dissent CLI Integration

## Overview
Implement the `--dissent` flag in `query.py` to expose the engine's "Constructive Dissent" feature. This feature mathematically detects minority opinions during the Stage 2 Peer Review process and surfaces them to the user.

## User Review Required
> [!NOTE]
> This feature is distinct from the Devil's Advocate. 
> - **Devil's Advocate**: A proactive critique from a reserved model.
> - **Constructive Dissent**: A reactive extraction of disagreements between models during the voting phase.

## Proposed Changes

### CLI Layer

#### [MODIFY] [query.py](file:///c:/git_projects/llm-council/query.py)
- Add `--dissent` argument to `argparse`.
- Update `run_full_council` call to include `include_dissent=args.dissent`.
- Add a new display section for `metadata.get("dissent")` in the terminal output.

### Verification Plan

#### Automated Tests
- Create `tests/test_dissent_integration.py` to verify that `run_full_council` correctly populates the `metadata["dissent"]` field when `include_dissent=True`.
- Run the full test suite `uv run pytest tests/ -v`.

#### Manual Verification
- Run a query with `--dissent` and models that are likely to disagree (e.g., a mix of GPT-4 and Haiku on a complex topic) to ensure the minority perspective is surfaced.


## Task List
- [x] Create implementation plan and GitHub issue
- [x] Create feature branch
- [/] Implement `--dissent` flag in `query.py`
- [ ] Pass `include_dissent` to `run_full_council` in `query.py`
- [ ] Implement display section for Constructive Dissent in `query.py`
- [ ] Create unit test for dissent integration
- [ ] Run full test suite and quality gates
- [ ] Final documentation and merge


## Walkthrough
# Walkthrough - Constructive Dissent CLI Integration

I have successfully integrated the "Constructive Dissent" feature into the LLM Council CLI (`query.py`).

## Features Implemented

1.  **--dissent Flag**:
    *   Exposed the engine's mathematical outlier detection logic to the terminal.
    *   This feature identifies models that gave significantly lower scores than the median during Stage 2 voting.
2.  **Dual Dissent Reports**:
    *   The CLI now supports both **Reactive Dissent** (Devil's Advocate Stage 1B) and **Constructive Dissent** (Statistical Phase 2).
    *   Each has its own dedicated output section for clarity.
3.  **Architectural Hardening**:
    *   Restored the gateway import architecture in `council.py`, ensuring `query_model_with_status` is available at the module level for robust testing and mocking.

## Changes Made

### CLI Layer
- [query.py](file:///c:/git_projects/llm-council/query.py): 
    - Added `--dissent` to argument parsing.
    - Updated orchestration call to include `include_dissent=args.dissent`.
    - Implemented a display block using a dotted border (`. . .`) to distinguish statistical dissent from the Devil's Advocate's bang border (`! ! !`).

### Integration Tests
- [test_dissent_integration.py](file:///c:/git_projects/llm-council/tests/test_dissent_integration.py): Verified that the `metadata['dissent']` payload is correctly populated when the flag is enabled.

## Verification Results

### Automated Tests
I ran the full council test suite (2695 tests) to ensure zero regressions across the codebase.
```bash
uv run pytest tests/ -v
===== 2695 passed, 10 skipped, 1 xfailed, 5 warnings in 76.14s (0:01:16) ======
```

## How to execute
Run a query with the new flag:
```bash
uv run python query.py "Your question" --dissent
```

You can also combine it with the Devil's Advocate for maximum rigor:
```bash
uv run python query.py "Your question" --adversary --dissent
```

