### PR TITLE
docs: Dissent and Devil's Advocate documentation and MCP wiring

### DIFF
--- a/docs/guides/how_to_use_llm_council_with_claude_desktop.md
+++ b/docs/guides/how_to_use_llm_council_with_claude_desktop.md
@@ -24,7 +24,8 @@ Now you can simply talk to Claude and ask him to use the council.
 ### Example Queries:
 * **Classic Query**: *"Ask the LLM Council about [Your Question]."*
 * **Deep Details**: *"Consult the Council about [Your Question] and **show me the Stage 1 details and thinking**."*
-* **Dissenting Opinions**: *"Ask the Council about [Hard Problem] and **include any dissenting opinions** from the peer review stage."*
+* **Devil's Advocate**: *"Ask the Council to **audit** its consensus on [Problem] using the **Devil's Advocate**."* (This triggers `adversarial_mode`).
+* **Statistical Dissent**: *"Ask the Council about [Hard Problem] and **include any dissenting opinions** from the peer review stage."* (This triggers `include_dissent`).
 
 ## 4. Key Configuration
 * **Project Location**: `c:\git_projects\llm-council`
@@ -45,7 +46,10 @@ C:\Users\carte\.local\bin\uv.exe --directory "c:\git_projects\llm-council" run p
 
 ### Advanced Flags:
 * **`--details`**: Displays the raw, unedited Stage 1 responses from every model in the council.
-* **`--confidence [quick|balanced|high]`**: Determines which tier of models are called (e.g., `--confidence quick` for cheaper/faster results).
+* **`--confidence [quick|balanced|high|reasoning]`**: Determines which tier of models are called.
+* **`--no-cache`**: Bypasses the cache and forces a fresh deliberation.
+* **`--adversary`**: Enables the **Forensic Auditor** (Devil's Advocate) who proactively finds flaws in the group's logic before the final synthesis.
+* **`--dissent`**: Enables **Constructive Dissent** extraction, which mathematically identifies minority opinions from the voting phase.
 
 ---
 
@@ -63,13 +67,14 @@ You have full control over which models participate in the deliberation by editi
 ## 7. Transparency & Detail Levels
 Depending on whether you use the Terminal or Claude Desktop, you have different options for seeing "under the hood" of the council:
 
-| Feature | Terminal (`--details`) | Claude (`include_details`) |
+| Feature | Terminal | Claude |
 | :--- | :---: | :---: |
 | **Raw Stage 1 Texts** | ✅ | ✅ |
 | **Borda Ranking Scores** | ✅ | ✅ |
+| **Statistical Dissent** | ✅ | ✅ |
+| **Forensic Auditor (DA)** | ✅ | ✅ |
 | **Model Latency/Status** | ❌ | ✅ |
 | **Advanced Quality Metrics** | ❌ | ✅ |
-| **Dissenting Opinions** | ❌ | ✅ |
 
 ---
 

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -135,6 +135,7 @@ async def consult_council(
     include_details: bool = False,
     verdict_type: str = "synthesis",
     include_dissent: bool = False,
+    adversarial_mode: Optional[bool] = None,
     ctx: Optional[Context] = None,
 ) -> str:
     """
@@ -149,6 +150,7 @@ async def consult_council(
             - "binary": Go/no-go decision (approved/rejected) with confidence score
             - "tie_breaker": Chairman resolves deadlocked decisions
         include_dissent: If True, extract minority opinions from Stage 2 evaluations (ADR-025b).
+        adversarial_mode: Optional[bool] = None, manually toggle Reactive Devil's Advocate (Stage 1B).
         ctx: MCP context for progress reporting (injected automatically).
 
     Returns:
@@ -195,6 +197,7 @@ async def consult_council(
         tier_contract=tier_contract,
         verdict_type=verdict_type_enum,
         include_dissent=include_dissent,
+        adversarial_mode=adversarial_mode,
     )
 
     # Extract results from ADR-012 structured response


### PR DESCRIPTION
Updates the Claude Desktop guide to include documentation for --adversary and --dissent flags, and wires the parameters into the MCP tool for parity.