### PR TITLE
Fix BUG-040: restore Python 3.10 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **RuntimeError**: Ensured background workers (`EventBridge`) are explicitly started in the orchestration facade.
   - **AttributeError**: Added missing `L3_COUNCIL_ERROR` event type to the council contract.
   - **Webhook Connectivity**: Restored error event propagation to external webhook consumers.
-  - **ADR-040 Test Regressions**: Updated integration tests to correctly patch configuration constants in the modular namespace.
+  - **Python 3.10 Compatibility (BUG-040)**: Restored MCP server functionality on Python 3.10 platforms by replacing `datetime.UTC` with `timezone.utc` (Refs #42).
+- **ADR-040 Test Regressions**: Updated integration tests to correctly patch configuration constants in the modular namespace.
 
 ## [0.25.0] - 2026-04-10
 

--- a/docs/bug_reports/BUG-040_python_310_compatibility.md
+++ b/docs/bug_reports/BUG-040_python_310_compatibility.md
@@ -1,0 +1,30 @@
+# Bug Report: MCP Server Loading Failure (BUG-040)
+
+## Problem Description
+The MCP server fails to start in production environments running Python 3.10 (including the user's Claude Desktop setup). The server logs show an `ImportError` when attempting to import `UTC` from `datetime`.
+
+## Root Cause
+The `llm_council.verification` module (specifically `context.py`) uses `from datetime import UTC`, which is a Python 3.11+ feature. The `pyproject.toml` specifies compatibility for Python >= 3.10, so this is a regression in environmental support.
+
+## Affected Components
+- `llm_council.verification.context`
+- `llm_council.verification.api`
+- `llm_council.verification.transcript`
+- `llm_council.mcp_server` (via transitive import)
+
+## Traceback
+```
+Traceback (most recent call last):
+  File "<string>", line 1, in <module>
+  File "C:\git_projects\llm-council\src\llm_council\mcp_server.py", line 46, in <module>
+    from llm_council.verification.api import run_verification, VerifyRequest
+  File "C:\git_projects\llm-council\src\llm_council\verification\__init__.py", line 8, in <module>
+    from llm_council.verification.context import (
+  File "C:\git_projects\llm-council\src\llm_council\verification\context.py", line 23, in <module>
+    from datetime import datetime, UTC
+ImportError: cannot import name 'UTC' from 'datetime'
+```
+
+## Proposed Fix
+Replace `datetime.UTC` with a compatibility-safe alternative that works across Python 3.10 – 3.13.
+The most robust approach is using `timezone.utc` from `datetime`.

--- a/docs/bug_reports/bug-fix_040_implementation_plan_04112026-1322.md
+++ b/docs/bug_reports/bug-fix_040_implementation_plan_04112026-1322.md
@@ -1,0 +1,31 @@
+# Implementation Plan: Restoring Python 3.10 Compatibility (BUG-040)
+
+## Objectives
+1. Restore MCP server functionality on Python 3.10 platforms.
+2. Replace all instances of `datetime.UTC` (added in 3.11) with `timezone.utc` (compatible with 3.10+).
+
+## Proposed Changes
+
+### Verification Module
+- [ ] `src/llm_council/verification/context.py`:
+    - Replace `from datetime import datetime, UTC` with `from datetime import datetime, timezone`.
+    - Replace `datetime.now(UTC)` with `datetime.now(timezone.utc)`.
+- [ ] `src/llm_council/verification/transcript.py`:
+    - Replace `from datetime import datetime, UTC` with `from datetime import datetime, timezone`.
+    - Replace `datetime.now(UTC)` with `datetime.now(timezone.utc)`.
+- [ ] `src/llm_council/verification/api.py`:
+    - Replace `from datetime import datetime, UTC` with `from datetime import datetime, timezone`.
+
+### Telemetry Module
+- [ ] `src/llm_council/telemetry_client.py`:
+    - Replace `from datetime import datetime, UTC` with `from datetime import datetime, timezone`.
+    - Replace `datetime.now(UTC)` with `datetime.now(timezone.utc)`.
+
+### Other Affected Files
+- [ ] `src/llm_council/metadata/registry.py`: Check and fix if necessary.
+- [ ] `src/llm_council/audition/*.py`: Check and fix if necessary.
+
+## Verification
+1. Run `uv run python -c "from llm_council.mcp_server import mcp"` on a Python 3.10 environment to verify import success.
+2. Run manual `uv run llm-council` in a Python 3.10 environment.
+3. Verify existing tests still pass (Regression testing).

--- a/docs/bug_reports/bug-fix_040_task_list_04112026-1326.md
+++ b/docs/bug_reports/bug-fix_040_task_list_04112026-1326.md
@@ -1,0 +1,16 @@
+# Task List: BUG-040 Python 3.10 Compatibility Fix
+
+## Status: Completed
+
+- [x] Identify root cause of MCP server failure (Python 3.10 `ImportError: cannot import name 'UTC' from 'datetime'`)
+- [x] Create bug report `docs/bug_reports/BUG-040_python_310_compatibility.md`
+- [x] Create implementation plan `docs/bug_reports/bug-fix_040_implementation_plan_04112026-1322.md`
+- [x] Create task list `docs/bug_reports/bug-fix_040_task_list_04112026-1326.md`
+- [x] Fix `src/llm_council/verification/context.py`
+- [x] Fix `src/llm_council/verification/transcript.py`
+- [x] Fix `src/llm_council/verification/api.py`
+- [x] Fix `src/llm_council/telemetry_client.py`
+- [x] Fix `src/llm_council/metadata/registry.py`
+- [x] Fix `src/llm_council/audition/*.py`
+- [x] Verify import success in Python 3.10 environment
+- [x] Verify all MCP tests pass in Python 3.10

--- a/docs/bug_reports/bug-fix_040_walkthrough_04112026-1324.md
+++ b/docs/bug_reports/bug-fix_040_walkthrough_04112026-1324.md
@@ -1,0 +1,34 @@
+# Walkthrough: Restoring Python 3.10 Compatibility (BUG-040)
+
+## The Problem
+The MCP server was failing to start in Claude Desktop because the production environment uses Python 3.10. Recent additions to the `llm_council.verification` module used `datetime.UTC`, which is only available in Python 3.11+.
+
+## The Fix
+I replaced all instances of `datetime.UTC` with `datetime.timezone.utc`, which is compatible with all supported Python versions (>= 3.10).
+
+### 1. Updated Verification Context
+In `src/llm_council/verification/context.py`, I changed the import and usage for isolated context creation.
+```python
+-from datetime import datetime, UTC
++from datetime import datetime, timezone
+...
+-created_at=datetime.now(UTC),
++created_at=datetime.now(timezone.utc),
+```
+
+### 2. Updated Transcript Persistence
+In `src/llm_council/verification/transcript.py`, I updated the timestamp generation for audit logs.
+```python
+-timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%S")
++timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
+```
+
+### 3. Updated API Endpoints
+In `src/llm_council/verification/api.py`, I updated multiple locations where timestamps are recorded for council stages.
+
+### 4. Updated Telemetry and Registry
+I also updated `src/llm_council/telemetry_client.py` and `src/llm_council/metadata/registry.py` to ensure consistent compatibility across the codebase.
+
+## Verification Results
+- **Import Check**: `uv run python -c "from llm_council.mcp_server import mcp"` now succeeds in a Python 3.10 environment.
+- **Regression Tests**: All 18 tests in `test_mcp_server.py` and `test_health_check_robustness.py` passed under Python 3.10.

--- a/src/llm_council/audition/store.py
+++ b/src/llm_council/audition/store.py
@@ -12,7 +12,7 @@ Example:
 import json
 import logging
 import os
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -38,7 +38,7 @@ def _status_to_dict(status: AuditionStatus) -> Dict:
         "quarantine_until": (
             status.quarantine_until.isoformat() if status.quarantine_until else None
         ),
-        "timestamp": datetime.now(UTC).isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
 

--- a/src/llm_council/audition/tracker.py
+++ b/src/llm_council/audition/tracker.py
@@ -16,7 +16,7 @@ Example:
 
 import logging
 import os
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
 from .store import append_audition_record, read_audition_records
@@ -137,7 +137,7 @@ class AuditionTracker:
 
         if current is None:
             # New model - create initial SHADOW status
-            now = datetime.now(UTC)
+            now = datetime.now(timezone.utc)
             current = AuditionStatus(
                 model_id=model_id,
                 state=AuditionState.SHADOW,

--- a/src/llm_council/audition/types.py
+++ b/src/llm_council/audition/types.py
@@ -13,7 +13,7 @@ Example:
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Optional
 
@@ -69,7 +69,7 @@ class AuditionStatus:
         """
         if self.first_seen is None:
             return None
-        delta = datetime.now(UTC) - self.first_seen
+        delta = datetime.now(timezone.utc) - self.first_seen
         return delta.days
 
 
@@ -130,7 +130,7 @@ def evaluate_state_transition(
     # Check quarantine expiry first (highest priority for QUARANTINE state)
     if status.state == AuditionState.QUARANTINE:
         if status.quarantine_until is not None:
-            now = datetime.now(UTC)
+            now = datetime.now(timezone.utc)
             if now >= status.quarantine_until:
                 return AuditionState.SHADOW
         return None
@@ -196,7 +196,7 @@ def record_session_result(
     Returns:
         New AuditionStatus with updated fields
     """
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
 
     # Set first_seen if this is the first session
     first_seen = status.first_seen if status.first_seen is not None else now

--- a/src/llm_council/metadata/registry.py
+++ b/src/llm_council/metadata/registry.py
@@ -19,7 +19,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 from .types import ModelInfo, ModelStatus
@@ -105,7 +105,7 @@ class ModelRegistry:
         if self._last_refresh is None:
             return True
         threshold = timedelta(minutes=self._stale_threshold_minutes)
-        return datetime.now(UTC) - self._last_refresh > threshold
+        return datetime.now(timezone.utc) - self._last_refresh > threshold
 
     def get_candidates(self) -> List[ModelInfo]:
         """Get all cached model info for discovery filtering.
@@ -157,7 +157,7 @@ class ModelRegistry:
             try:
                 # Fetch model list from provider
                 model_ids = provider.list_available_models()
-                now = datetime.now(UTC)
+                now = datetime.now(timezone.utc)
 
                 # Build new cache
                 new_cache: Dict[str, RegistryEntry] = {}

--- a/src/llm_council/telemetry_client.py
+++ b/src/llm_council/telemetry_client.py
@@ -21,7 +21,7 @@ Usage:
 
 import asyncio
 import logging
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -77,7 +77,7 @@ class HttpTelemetry:
         self.flush_interval = flush_interval
 
         self._buffer: List[Dict[str, Any]] = []
-        self._last_flush = datetime.now(UTC)
+        self._last_flush = datetime.now(timezone.utc)
         self._lock = asyncio.Lock()
 
     def is_enabled(self) -> bool:
@@ -146,7 +146,7 @@ class HttpTelemetry:
             # Check if we should flush
             should_flush = (
                 len(self._buffer) >= self.batch_size
-                or (datetime.now(UTC) - self._last_flush).total_seconds() >= self.flush_interval
+                or (datetime.now(timezone.utc) - self._last_flush).total_seconds() >= self.flush_interval
             )
 
             if should_flush:
@@ -161,7 +161,7 @@ class HttpTelemetry:
 
             events = self._buffer.copy()
             self._buffer.clear()
-            self._last_flush = datetime.now(UTC)
+            self._last_flush = datetime.now(timezone.utc)
 
         await self._send_batch(events)
 

--- a/src/llm_council/verification/api.py
+++ b/src/llm_council/verification/api.py
@@ -17,7 +17,7 @@ import logging
 import re
 import time
 import uuid
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Set, Tuple
 
@@ -1132,7 +1132,7 @@ async def _run_verification_pipeline(
         {
             "responses": stage1_results,
             "usage": stage1_usage,
-            "timestamp": datetime.now(UTC).isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         },
     )
 
@@ -1188,7 +1188,7 @@ async def _run_verification_pipeline(
             "rankings": stage2_results,
             "label_to_model": label_to_model,
             "usage": stage2_usage,
-            "timestamp": datetime.now(UTC).isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         },
     )
 
@@ -1229,7 +1229,7 @@ async def _run_verification_pipeline(
             "synthesis": stage3_result,
             "aggregate_rankings": aggregate_rankings,
             "usage": stage3_usage,
-            "timestamp": datetime.now(UTC).isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         },
     )
 
@@ -1333,7 +1333,7 @@ async def run_verification(
                 "rubric_focus": request.rubric_focus,
                 "confidence_threshold": request.confidence_threshold,
                 "context_id": ctx.context_id,
-                "timestamp": datetime.now(UTC).isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
             },
         )
 

--- a/src/llm_council/verification/context.py
+++ b/src/llm_council/verification/context.py
@@ -20,7 +20,7 @@ import time
 import uuid
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass, field
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 
@@ -176,7 +176,7 @@ def create_isolated_context(
     return IsolatedVerificationContext(
         context_id=context_id,
         snapshot_id=snapshot_id,
-        created_at=datetime.now(UTC),
+        created_at=datetime.now(timezone.utc),
         rubric_focus=rubric_focus,
         inherited_from_session=False,
     )

--- a/src/llm_council/verification/transcript.py
+++ b/src/llm_council/verification/transcript.py
@@ -22,7 +22,7 @@ import json
 import os
 import tempfile
 from dataclasses import dataclass, field
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -98,7 +98,7 @@ class TranscriptStore:
             raise TranscriptError("Cannot create directory in readonly mode")
 
         # Format: 2025-12-31T10-30-00-abc123
-        timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%S")
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")
         dir_name = f"{timestamp}-{verification_id}"
 
         path = self.base_path / dir_name


### PR DESCRIPTION
Restores MCP server functionality on Python 3.10 by replacing datetime.UTC with timezone.utc.