### PR TITLE
Fix BUG-044: Enhance health check observability and calibrate Gemini default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Dynamic Connectivity**: Replaced hardcoded test model with the configured `CHAIRMAN_MODEL`.
   - **Auth Fallback**: Implemented an automated fallback to `openai/gpt-4o-mini` when the primary model is restricted, allowing the tool to remain functional if the API key itself is valid.
   - **Diagnostic Context**: Added `ready_warning` to the health check response to distinguish between restricted models and invalid API keys.
+- **Health Check Observability & Calibration (BUG-044)**: Enhanced diagnostic reporting and calibrated default models (Refs #44).
+  - **Credit Diagnostics**: Integrated OpenRouter `/credits` API into the health check to identify monthly usage limits.
+  - **Model Calibration**: Updated the global default `CHAIRMAN_MODEL` to `google/gemini-3.1-pro-preview` for high-tier synthesis.
+  - **Resilience**: Improved dual-403 failure messaging to differentiate between model restrictions and account-level credit blocks.
 - **ADR-040 Test Regressions**: Updated integration tests to correctly patch configuration constants in the modular namespace.
 
 ## [0.25.0] - 2026-04-10

--- a/docs/bug_reports/BUG-044_obs_calibration.md
+++ b/docs/bug_reports/BUG-044_obs_calibration.md
@@ -1,0 +1,18 @@
+# BUG-044: Health Check Observability & Default Calibration
+
+## Description
+The `council_health_check` was providing a generic `403 Forbidden` error when an API key reached its monthly usage limit on OpenRouter. This led to confusion about whether the code was faulty (hardcoded models) or the environment was restricted. Furthermore, the system defaulted to a mid-tier synthesis model (`gemini-2.0-flash-001`) by default.
+
+## Root Cause
+- **Ambiguity**: The health check did not distinguish between `401 Unauthorized` (bad key) and `403 Forbidden` (account/policy restriction).
+- **Zero Visibility**: No balance or credit check was performed during the health check.
+- **Stale Defaults**: The hardcoded default chairman model was outdated.
+
+## Proposed Strategy
+1. **Differentiate 403 Failures**: Use a "lite" fallback model (`gpt-4o-mini`) to verify key validity when the primary fails.
+2. **Account Balances**: Call OpenRouter's `/credits` API and report the status in the health check.
+3. **Calibrate Defaults**: Set the system-wide default chairman to `google/gemini-3.1-pro-preview`.
+
+## Verification Strategy
+- **Manual**: Run `council_health_check` and verify the `account_credits` field shows either a balance or a specific error code.
+- **Automated**: Verify that an invalid key returns a `401` while a restricted key (balance/limit) returns a `403` with a specific `ready_warning`.

--- a/llm_council.yaml
+++ b/llm_council.yaml
@@ -6,6 +6,7 @@ timeouts:
 
 council:
   adversarial_mode: false
+  chairman: "google/gemini-3.1-pro-preview"
 
 tiers:
   default: balanced

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -364,7 +364,26 @@ async def council_health_check() -> str:
             "balanced": "~45-60 seconds (most models)",
             "high": f"~60-90 seconds (all {len(COUNCIL_MODELS)} models)",
         },
+        "account_credits": "unknown",
     }
+
+    # Fetch credits if possible (ADR-013 diagnostics)
+    if checks["api_key_configured"]:
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                api_key = _get_openrouter_api_key()
+                headers = {
+                    "Authorization": f"Bearer {api_key}",
+                    "HTTP-Referer": "https://github.com/mgammarino/llm-council",
+                }
+                credit_resp = await client.get("https://openrouter.ai/api/v1/credits", headers=headers)
+                if credit_resp.status_code == 200:
+                    data = credit_resp.json().get("data", {})
+                    checks["account_credits"] = f"${data.get('total_credits', 0):.2f}"
+                else:
+                    checks["account_credits"] = f"Error: {credit_resp.status_code}"
+        except Exception as e:
+            checks["account_credits"] = f"Error: {str(e)}"
 
     if checks["api_key_configured"]:
         try:

--- a/src/llm_council/mcp_server.py
+++ b/src/llm_council/mcp_server.py
@@ -1,4 +1,5 @@
 import os
+import httpx
 import sys
 import time
 import json

--- a/src/llm_council/unified_config.py
+++ b/src/llm_council/unified_config.py
@@ -756,7 +756,7 @@ class CouncilConfig(BaseModel):
         alias="LLM_COUNCIL_MODELS",
     )
     chairman: str = Field(
-        default="openai/gpt-4o",
+        default="google/gemini-3.1-pro-preview",
         alias="LLM_COUNCIL_CHAIRMAN",
     )
     synthesis_mode: Literal["consensus", "debate"] = Field(

--- a/tests/test_bug_044.py
+++ b/tests/test_bug_044.py
@@ -1,0 +1,61 @@
+import pytest
+import json
+from unittest.mock import patch, MagicMock
+from llm_council.mcp_server import council_health_check
+
+@pytest.mark.asyncio
+async def test_health_check_dual_403_warning():
+    """Verify that a double 403 Forbidden returns a critical warning (Refs #44)."""
+    
+    # Mock status_ok and status_auth_error correctly based on provider return types
+    # Our internal provider returns a dict with "status": "auth_error" for 403
+    
+    mock_response = {
+        "status": "auth_error",
+        "error": "Authentication failed for model: 403",
+        "latency_ms": 100
+    }
+    
+    with patch("llm_council.mcp_server.query_model_with_status", return_value=mock_response), \
+         patch("llm_council.mcp_server._get_openrouter_api_key", return_value="fake-key"), \
+         patch("httpx.AsyncClient.get") as mock_get:
+        
+        # Mock the credits API to also return 403
+        mock_get.return_value = MagicMock(status_code=403)
+        
+        result_json = await council_health_check()
+        result = json.loads(result_json)
+        
+        # 1. Ready should be False
+        assert result["ready"] is False
+        
+        # 2. Ready warning should contain the Critical message
+        assert "Critical: Both chairman" in result["ready_warning"]
+        assert "returned 403" in result["ready_warning"]
+        
+        # 3. Credits should show the error code
+        assert result["account_credits"] == "Error: 403"
+
+@pytest.mark.asyncio
+async def test_health_check_success_with_credits():
+    """Verify that a successful check displays credits (Refs #44)."""
+    
+    mock_success = {
+        "status": "ok",
+        "content": "pong",
+        "latency_ms": 100
+    }
+    
+    with patch("llm_council.mcp_server.query_model_with_status", return_value=mock_success), \
+         patch("llm_council.mcp_server._get_openrouter_api_key", return_value="fake-key"), \
+         patch("httpx.AsyncClient.get") as mock_get:
+        
+        # Mock the credits API to return success
+        mock_data = {"data": {"total_credits": 25.50}}
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: mock_data)
+        
+        result_json = await council_health_check()
+        result = json.loads(result_json)
+        
+        assert result["ready"] is True
+        assert result["account_credits"] == "$25.50"


### PR DESCRIPTION
## Description
Resolves #44 by adding credit diagnostics to the health check and calibrating the default chairman model.

## Changes
- **MCP Server**: Added ccount_credits check to council_health_check.
- **MCP Server**: Added resilient error messaging for dual-model 403 Forbidden failures.
- **Unified Config**: Calibrated default CHAIRMAN_MODEL to google/gemini-3.1-pro-preview.
- **Tests**: Added regression tests in 	ests/test_bug_044.py.

## Verification
- [x] Pytest results: 2 passed.
- [x] Manual verification of credit diagnostics.